### PR TITLE
clang-format: enforce line breaks after the template closer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -118,6 +118,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Linux
 BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTemplateCloser: true
 BreakBeforeTernaryOperators: true
 BreakBinaryOperations: Never
 BreakConstructorInitializers: BeforeColon

--- a/include/qiskit/addon/sqd/configuration_recovery.hpp
+++ b/include/qiskit/addon/sqd/configuration_recovery.hpp
@@ -189,7 +189,8 @@ void _bipartite_bitstring_correcting(
 ///     probability array.
 template <
     typename BitstringVectorType, typename WeightVectorType,
-    QKA_SQD_CONCEPT_RNG_(RNGType)>
+    QKA_SQD_CONCEPT_RNG_(RNGType)
+>
 [[nodiscard]] std::pair<BitstringVectorType, WeightVectorType> recover_configurations(
     const BitstringVectorType &bitstrings, const WeightVectorType &probabilities,
     const std::array<std::vector<double>, 2> &avg_occupancies,

--- a/include/qiskit/addon/sqd/fermion.hpp
+++ b/include/qiskit/addon/sqd/fermion.hpp
@@ -59,8 +59,9 @@ template <class BitstringVectorType>
 auto bitstrings_to_ci_strings_symmetrize_spin(
     const BitstringVectorType &bitstrings,
     std::optional<unsigned int> max_dimension = std::nullopt,
-    std::optional<std::reference_wrapper<const std::vector<
-        internal::HalfSize<typename BitstringVectorType::value_type>>>>
+    std::optional<std::reference_wrapper<
+        const std::vector<internal::HalfSize<typename BitstringVectorType::value_type>>
+    >>
         include_configurations = std::nullopt
 ) -> std::vector<internal::HalfSize<typename BitstringVectorType::value_type>>
 {

--- a/include/qiskit/addon/sqd/postselection.hpp
+++ b/include/qiskit/addon/sqd/postselection.hpp
@@ -101,7 +101,8 @@ class MatchesRightLeftHamming
 ///         bitstrings, weights, Qiskit::addon::sqd::MatchesRightLeftHamming(1, 2)
 ///     );
 template <
-    typename BitstringVectorType, typename WeightVectorType, typename CallableType>
+    typename BitstringVectorType, typename WeightVectorType, typename CallableType
+>
 std::pair<BitstringVectorType, WeightVectorType> postselect_bitstrings(
     const BitstringVectorType &bitstrings, const WeightVectorType &weights,
     CallableType filter_function

--- a/include/qiskit/addon/sqd/subsampling.hpp
+++ b/include/qiskit/addon/sqd/subsampling.hpp
@@ -58,7 +58,8 @@ namespace sqd
 /// @tparam RNGType Type of random number generator.
 template <
     typename BatchVectorType, typename BitstringVectorType, typename WeightVectorType,
-    typename RNGType>
+    typename RNGType
+>
 void subsample(
     BatchVectorType &batch, const BitstringVectorType &bitstrings,
     const WeightVectorType &weights, unsigned int samples_per_batch, RNGType &rng
@@ -150,7 +151,8 @@ BitstringVectorType subsample(
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 template <
     typename BatchesVectorType, typename BitstringVectorType, typename WeightVectorType,
-    typename RNGType>
+    typename RNGType
+>
 void subsample_multiple_batches(
     BatchesVectorType &batches, const BitstringVectorType &bitstrings,
     const WeightVectorType &weights, unsigned int samples_per_batch,

--- a/include/qiskit/addon/sqd/subsampling.hpp
+++ b/include/qiskit/addon/sqd/subsampling.hpp
@@ -116,7 +116,8 @@ void subsample(
 /// @return The subsampled bitstrings.
 template <
     typename BitstringVectorType, typename WeightVectorType,
-    QKA_SQD_CONCEPT_RNG_(RNGType)>
+    QKA_SQD_CONCEPT_RNG_(RNGType)
+>
 BitstringVectorType subsample(
     const BitstringVectorType &bitstrings, const WeightVectorType &weights,
     unsigned int samples_per_batch, RNGType &rng
@@ -189,7 +190,8 @@ void subsample_multiple_batches(
 /// @return The batches of subsampled bitstrings.
 template <
     typename BitstringVectorType, typename WeightVectorType,
-    QKA_SQD_CONCEPT_RNG_(RNGType)>
+    QKA_SQD_CONCEPT_RNG_(RNGType)
+>
 std::vector<BitstringVectorType> subsample_multiple_batches(
     const BitstringVectorType &bitstrings, const WeightVectorType &weights,
     unsigned int samples_per_batch, unsigned int num_batches, RNGType &rng

--- a/include/qiskit/addon/sqd/subsampling.hpp
+++ b/include/qiskit/addon/sqd/subsampling.hpp
@@ -154,12 +154,8 @@ BitstringVectorType subsample(
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 template <
     typename BatchesVectorType, typename BitstringVectorType, typename WeightVectorType,
-<<<<<<< HEAD
-    typename RNGType
+    QKA_SQD_CONCEPT_RNG_(RNGType)
 >
-=======
-    QKA_SQD_CONCEPT_RNG_(RNGType)>
->>>>>>> main
 void subsample_multiple_batches(
     BatchesVectorType &batches, const BitstringVectorType &bitstrings,
     const WeightVectorType &weights, unsigned int samples_per_batch,


### PR DESCRIPTION
IMO, this is more readable and consistent with Black style, but it requires clang-format 21, which is not yet available in a stable Fedora version.  So I plan to hold off merging this for a bit.