### PR TITLE
Normalize occupancies prior to configuration recovery

### DIFF
--- a/include/qiskit/addon/sqd/configuration_recovery.hpp
+++ b/include/qiskit/addon/sqd/configuration_recovery.hpp
@@ -224,7 +224,7 @@ template <
         double density_s = static_cast<double>(num_elec[s]) / partition_size;
         // NOLINTEND(bugprone-narrowing-conversions)
         for (std::size_t i = 0; i < partition_size; ++i) {
-            const auto occ = avg_occupancies[s][i];
+            const auto occ = std::max(0.0, std::min(1.0, avg_occupancies[s][i]));
             probs_table[s][0][i] = internal::_p_flip_0_to_1(density_s, occ);
             probs_table[s][1][i] = internal::_p_flip_1_to_0(density_s, occ);
         }

--- a/test/test_configuration_recovery.cpp
+++ b/test/test_configuration_recovery.cpp
@@ -78,7 +78,8 @@ TEST_CASE("Configuration recovery tests from python addon")
         const std::vector<std::bitset<num_orbs>> bitstrings(1);
         const std::vector<double> probs(1, 1.0);
         std::array<std::vector<double>, 2> occs{
-            std::vector<double>(half_orbs, 1.0), std::vector<double>(half_orbs, 1.0)
+            std::vector<double>(half_orbs, 1.000001),
+            std::vector<double>(half_orbs, 1.0)
         };
         auto [mat_rec, probs_rec] =
             recover_configurations(bitstrings, probs, occs, {ham_r, ham_l}, rng);
@@ -96,7 +97,7 @@ TEST_CASE("Configuration recovery tests from python addon")
         const std::vector<std::bitset<num_orbs>> bitstrings(1, 0b1111);
         const std::vector<double> probs(1, 1.0);
         std::array<std::vector<double>, 2> occs{
-            std::vector<double>(half_orbs), std::vector<double>(half_orbs)
+            std::vector<double>(half_orbs, -1e6), std::vector<double>(half_orbs)
         };
         auto [mat_rec, probs_rec] =
             recover_configurations(bitstrings, probs, occs, {ham_r, ham_l}, rng);


### PR DESCRIPTION
This changes the configuration recovery code to truncate the occupancy values so that they are between 0 and 1.  With this change, it should accept as input any float except NaN.

The old code presented a problem because the capi-demo code could result in giving it values that were 1e-16 above 1.0 and then failing, because it would then calculate negative weights for sampling.